### PR TITLE
Updated brer_plugin to support premature advancement fixes in run_brer

### DIFF
--- a/src/cpp/linearstoppotential.cpp
+++ b/src/cpp/linearstoppotential.cpp
@@ -78,7 +78,7 @@ void LinearStop::callback(gmx::Vector v, gmx::Vector v0, double t,
   }
 
   if (converged) {
-    if !(stop_called_) {
+    if (!stop_called_) {
       stop_called_ = true;
       writeparameters(t, R);
       //                fprintf(logging_file_->fh(), "Simulation converged at t

--- a/src/cpp/linearstoppotential.cpp
+++ b/src/cpp/linearstoppotential.cpp
@@ -78,8 +78,8 @@ void LinearStop::callback(gmx::Vector v, gmx::Vector v0, double t,
   }
 
   if (converged) {
-    if (stop_not_called_) {
-      stop_not_called_ = false;
+    if !(stop_called_) {
+      stop_called_ = true;
       writeparameters(t, R);
       //                fprintf(logging_file_->fh(), "Simulation converged at t
       //                == %f", t);

--- a/src/cpp/linearstoppotential.h
+++ b/src/cpp/linearstoppotential.h
@@ -58,7 +58,7 @@ public:
                 const Resources &resources);
 
   double getTime() { return time_; }
-  bool getStop() { return stop_called_; }
+  bool getStopCalled() { return stop_called_; }
 
 private:
   bool initialized_{false};
@@ -78,7 +78,7 @@ private:
 
   std::string logging_filename_;
   std::unique_ptr<RAIIFile> logging_file_{nullptr};
-  bool stop_called{false};
+  bool stop_called_{false};
 };
 
 // implement IRestraintPotential in terms of LinearStop
@@ -128,6 +128,7 @@ public:
   }
 
   using LinearStop::getTime;
+  using LinearStop::getStopCalled;
 
 private:
   std::vector<int> sites_;

--- a/src/cpp/linearstoppotential.h
+++ b/src/cpp/linearstoppotential.h
@@ -58,6 +58,7 @@ public:
                 const Resources &resources);
 
   double getTime() { return time_; }
+  bool getStop() { return stop_called_; }
 
 private:
   bool initialized_{false};
@@ -77,7 +78,7 @@ private:
 
   std::string logging_filename_;
   std::unique_ptr<RAIIFile> logging_file_{nullptr};
-  bool stop_not_called_{true};
+  bool stop_called{false};
 };
 
 // implement IRestraintPotential in terms of LinearStop

--- a/src/pythonmodule/export_plugin.cpp
+++ b/src/pythonmodule/export_plugin.cpp
@@ -644,6 +644,10 @@ PYBIND11_MODULE(brer, m){
       m, "LinearStopRestraint");
   // EnsembleRestraint can only be created via builder for now.
   linearStop.def("bind", &PyLinearStop::bind, "Implement binding protocol");
+  linearStop.def_property_readonly("stop_called", [](PyLinearStop *potential) {
+    return static_cast<plugin::LinearStopRestraint *>(potential->getRestraint().get())
+        ->getStopCalled();
+  });
   linearStop.def_property_readonly("time", [](PyLinearStop *potential) {
     return static_cast<plugin::LinearStopRestraint *>(potential->getRestraint().get())
         ->getTime();


### PR DESCRIPTION
Placed suggestions into `brer_plugin`. Question: Do all suggestions in #19 give a full solution? `linearstoppotential.cpp` has additional lines: 
```c++
params->alpha = alpha;
  params->tolerance = tolerance;
  params->target = target;
  params->samplePeriod = samplePeriod;
  params->logging_filename = logging_filename;
  ```
  
  and we should add `params->stop_called = stop+called;` ? 