### PR TITLE
Export trajectory times for the BRER production phase.

### DIFF
--- a/src/cpp/linearpotential.cpp
+++ b/src/cpp/linearpotential.cpp
@@ -67,6 +67,7 @@ gmx::PotentialPointData Linear::calculate(gmx::Vector v, gmx::Vector v0,
                                           double t) {
   // Our convention is to calculate the force that will be applied to v.
   // An equal and opposite force is applied to v0.
+  time_ = t;
   auto rdiff = v - v0;
   const auto Rsquared = dot(rdiff, rdiff);
   const auto R = sqrt(Rsquared);

--- a/src/cpp/linearpotential.h
+++ b/src/cpp/linearpotential.h
@@ -46,8 +46,13 @@ public:
   void callback(gmx::Vector v, gmx::Vector v0, double t,
                 const Resources &resources);
 
+  double getTime() const { return time_; }
+  double getStartTime() const { return startTime_; }
+
 private:
   bool initialized_{false};
+  double time_{0};
+
   double alpha_;
 
   /// target distance
@@ -90,6 +95,9 @@ public:
   void setResources(std::unique_ptr<Resources> &&resources) {
     resources_ = std::move(resources);
   }
+
+  using Linear::getTime;
+  using Linear::getStartTime;
 
 private:
   std::vector<int> sites_;

--- a/src/pythonmodule/export_plugin.cpp
+++ b/src/pythonmodule/export_plugin.cpp
@@ -613,6 +613,22 @@ PYBIND11_MODULE(brer, m){
   py::class_<PyLinear, std::shared_ptr<PyLinear>> linear(m, "LinearRestraint");
   // EnsembleRestraint can only be created via builder for now.
   linear.def("bind", &PyLinear::bind, "Implement binding protocol");
+  linear.def_property_readonly(
+      "time",
+      [](PyLinear *potential) {
+        return static_cast<plugin::LinearRestraint *>(
+                   potential->getRestraint().get())
+            ->getTime();
+      },
+      "Simulation time for the last call to the force calculator.");
+  linear.def_property_readonly(
+      "start_time",
+      [](PyLinear *potential) {
+        return static_cast<plugin::LinearRestraint *>(
+                   potential->getRestraint().get())
+            ->getStartTime();
+      },
+      "Simulation time at which the plugin potential was initialized.");
 
   m.def("linear_restraint",
         [](const py::object element) { return createLinearBuilder(element); });


### PR DESCRIPTION
* Provide "time" for LinearRestraint the same as it is provided for
  LinearStopRestraint.
* Export the "start_time" that LinearRestraint already records (for
  logging purposes) to the Python interface.

See https://github.com/kassonlab/run_brer/issues/19