### PR TITLE
Added 'converged' as a potential in `export_plugin.cpp` for Issue #16

### DIFF
--- a/src/cpp/brerpotential.h
+++ b/src/cpp/brerpotential.h
@@ -96,6 +96,7 @@ public:
 
   double getAlphaMax() { return alpha_max_; }
   double getTarget() { return target_; }
+  bool getConverged() { return converged_;}
 
 private:
   bool initialized_{false};
@@ -182,6 +183,7 @@ public:
 
   using BRER::getAlphaMax;
   using BRER::getTarget;
+  using BRER::getConverged;
 
 private:
   std::vector<int> sites_;

--- a/src/pythonmodule/export_plugin.cpp
+++ b/src/pythonmodule/export_plugin.cpp
@@ -705,6 +705,10 @@ PYBIND11_MODULE(brer, m){
     return static_cast<plugin::BRERRestraint *>(potential->getRestraint().get())
         ->getTarget();
   });
+brer.def_property_readonly("converged", [](PyBRER *potential) {
+    return static_cast<plugin::BRERRestraint *>(potential->getRestraint().get())
+        ->getConverged();
+    });
 
   m.def("brer_restraint",
         [](const py::object element) { return createBRERBuilder(element); });


### PR DESCRIPTION
Updated `export_plugin.cpp` to include `converged` as a restraint parameter.
Fixes Issue #16 